### PR TITLE
at cron file is now in /etc/cron.d

### DIFF
--- a/libexec/atrun/atrun.man
+++ b/libexec/atrun/atrun.man
@@ -16,7 +16,7 @@ runs jobs queued by
 The system
 .Xr crontab 5
 file
-.Pa /etc/crontab
+.Pa /etc/cron.d/at
 must contain the line
 .Bd -literal
 */5     *       *       *       *       root    /usr/libexec/atrun


### PR DESCRIPTION
Signed-off-by: Pawel Krawczyk <p+freebsd@krvtz.net>

Fix https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=243380